### PR TITLE
Sider selectedKey 활성화 변경

### DIFF
--- a/src/Root.tsx
+++ b/src/Root.tsx
@@ -1,11 +1,25 @@
 import React from 'react';
 import { BrowserRouter } from 'react-router-dom';
+import { Layout } from 'antd';
 import App from './components/App';
+import Sider from './components/base/Sider/Sider';
+import Header from './components/base/Header/Header';
+import Content from './components/base/Content/Content';
+import Footer from './components/base/Footer/Footer';
 
 const Root: React.FunctionComponent = () => {
     return (
         <BrowserRouter>
-            <App />
+            <Layout style={{ minHeight: '100vh' }}>
+                <Sider />
+                <Layout>
+                    <Header />
+                    <Content>
+                        <App />
+                    </Content>
+                    <Footer />
+                </Layout>
+            </Layout>
         </BrowserRouter>
     );
 };

--- a/src/components/App.tsx
+++ b/src/components/App.tsx
@@ -1,19 +1,21 @@
 import React from 'react';
 import { Switch, Route } from 'react-router-dom';
-import DashboardContaniner from '../containers/dashboards/Dashboard';
-import DataSourceContaniner from '../containers/datasources/DataSource';
-import Home from './home/Home';
-import Users from './users/User';
 
-// import importedComponent from 'react-imported-component';
-// const AsyncDashboard = importedComponent(() => import(/* webpackChunkName:'Dashboard' */ './dasboards/Dashboard'));
-// const AsyncUser = importedComponent(() => import(/* webpackChunkName:'User' */ './users/User'));
+import importedComponent from 'react-imported-component';
+const AsyncDashboard = importedComponent(() =>
+    import(/* webpackChunkName:'Dashboard' */ '../containers/dashboards/Dashboard'),
+);
+const AsyncDataSource = importedComponent(() =>
+    import(/* webpackChunkName:'Datasource' */ '../containers/datasources/DataSource'),
+);
+const AsyncHome = importedComponent(() => import(/* webpackChunkName:'Datasource' */ '../containers/home/Home'));
 
 const App = () => {
     return (
         <Switch>
-            <Route exact path='/dashboard' component={DashboardContaniner} />
-            <Route exact path='/datasource' component={DataSourceContaniner} />
+            <Route exact path='/' component={AsyncHome} />
+            <Route exact path='/datasource' component={AsyncDataSource} />
+            <Route exact path='/dashboard' component={AsyncDashboard} />
         </Switch>
     );
 };

--- a/src/components/base/Sider/Sider.tsx
+++ b/src/components/base/Sider/Sider.tsx
@@ -1,19 +1,17 @@
 import React, { useState } from 'react';
 import { Layout, Menu, Icon } from 'antd';
-import { Link } from 'react-router-dom';
+import { withRouter, Link, RouteComponentProps } from 'react-router-dom';
 import styles from './Sider.scss';
 const { Sider } = Layout;
-interface Props {
-    url: string;
-}
-const SiderFC: React.FunctionComponent<Props> = ({ children, url }) => {
+interface Props extends RouteComponentProps {}
+const SiderFC: React.FunctionComponent<Props> = ({ children, location }) => {
     const [collapsed, setCollapsed] = useState(false);
     return (
         <Sider trigger={null} collapsible collapsed={collapsed}>
-            <Link to='/datasource'>
+            <Link to='/'>
                 <div className={styles.logo} />
             </Link>
-            <Menu theme='dark' defaultSelectedKeys={['/datasource']} selectedKeys={[url]} mode='inline'>
+            <Menu theme='dark' defaultSelectedKeys={['/']} selectedKeys={[location.pathname]} mode='inline'>
                 <Menu.Item key='/datasource'>
                     <Link to='/datasource'>
                         <Icon type='database' />
@@ -26,41 +24,8 @@ const SiderFC: React.FunctionComponent<Props> = ({ children, url }) => {
                         Dashboard
                     </Link>
                 </Menu.Item>
-                {/* <SubMenu
-                    key='sub1'
-                    title={
-                        <span>
-                            <Icon type='pie-chart' />
-                            <span>Metrics</span>
-                        </span>
-                    }
-                >
-                    <Menu.Item key='3'>
-                        <span>metric1</span>
-                    </Menu.Item>
-                    <Menu.Item key='4'>
-                        <span>metric2</span>
-                    </Menu.Item>
-                    <Menu.Item key='5'>
-                        <span>metric3</span>
-                    </Menu.Item>
-                </SubMenu>
-                <SubMenu
-                    key='sub2'
-                    title={
-                        <span>
-                            <Icon type='project' />
-                            <span>Monitors</span>
-                        </span>
-                    }
-                >
-                    <Menu.Item key='6'>monitor1</Menu.Item>
-                    <Menu.Item key='7'>monitor2</Menu.Item>
-                    <Menu.Item key='8'>monitor3</Menu.Item>
-                </SubMenu> */}
             </Menu>
         </Sider>
     );
 };
-
-export default SiderFC;
+export default withRouter(SiderFC);

--- a/src/components/dasboards/Dashboard.tsx
+++ b/src/components/dasboards/Dashboard.tsx
@@ -5,11 +5,7 @@ interface Props {
     url: string;
 }
 const Dashboard: React.FunctionComponent<Props> = ({ children, url }) => {
-    return (
-        <LayoutCommon url={url}>
-            <div className={styles.dashboard}>{children}</div>
-        </LayoutCommon>
-    );
+    return <div className={styles.dashboard}>{children}</div>;
 };
 
 export default Dashboard;

--- a/src/components/datasources/DataSource.tsx
+++ b/src/components/datasources/DataSource.tsx
@@ -1,5 +1,4 @@
 import React, { useState } from 'react';
-import LayoutCommon from '../common/Layout/Layout';
 import styles from './DataSource.scss';
 import { Card, Row, Col } from 'antd';
 
@@ -20,36 +19,30 @@ const DataSource: React.FunctionComponent<Props> = ({ children, datasources, url
         setSelectedKey(name);
     };
     return (
-        <LayoutCommon url={url}>
-            <div className={styles.datasource}>
-                <h2>Selected Data Source {selectedKey && `[ ${selectedKey} ]`}</h2>
-                <Row gutter={16}>
-                    {datasources.length > 0 &&
-                        datasources.map(datasource => {
-                            return (
-                                <span key={datasource.name} onClick={e => onSelect(e, datasource.name)}>
-                                    <Col span={6}>
-                                        <Card
-                                            title={
-                                                <img
-                                                    className={styles.img}
-                                                    src={datasource.img}
-                                                    alt={datasource.name}
-                                                />
-                                            }
-                                            hoverable={true}
-                                            className={styles.card}
-                                            bordered={true}
-                                        >
-                                            <b>{datasource.name}</b>
-                                        </Card>
-                                    </Col>
-                                </span>
-                            );
-                        })}
-                </Row>
-            </div>
-        </LayoutCommon>
+        <div className={styles.datasource}>
+            <h2>Selected Data Source {selectedKey && `[ ${selectedKey} ]`}</h2>
+            <Row gutter={16}>
+                {datasources.length > 0 &&
+                    datasources.map(datasource => {
+                        return (
+                            <span key={datasource.name} onClick={e => onSelect(e, datasource.name)}>
+                                <Col span={6}>
+                                    <Card
+                                        title={
+                                            <img className={styles.img} src={datasource.img} alt={datasource.name} />
+                                        }
+                                        hoverable={true}
+                                        className={styles.card}
+                                        bordered={true}
+                                    >
+                                        <b>{datasource.name}</b>
+                                    </Card>
+                                </Col>
+                            </span>
+                        );
+                    })}
+            </Row>
+        </div>
     );
 };
 

--- a/src/components/home/Home.tsx
+++ b/src/components/home/Home.tsx
@@ -1,13 +1,7 @@
 import React from 'react';
-import Layout from 'antd/lib/layout';
-import LayoutCommon from '../common/Layout/Layout';
 import styles from './Home.scss';
 
 const Home: React.FunctionComponent = children => {
-    return (
-        <LayoutCommon>
-            <div className={styles.home1123}>This is Home</div>
-        </LayoutCommon>
-    );
+    return <div className={styles.home1123}>This is Home</div>;
 };
 export default Home;

--- a/src/containers/home/Home.tsx
+++ b/src/containers/home/Home.tsx
@@ -1,0 +1,10 @@
+import React, { Component } from 'react';
+import HomeComponent from '../../components/home/Home';
+
+class DataSourceContainers extends Component {
+    render() {
+        return <HomeComponent></HomeComponent>;
+    }
+}
+
+export default DataSourceContainers;


### PR DESCRIPTION
- Sider selecteKey 방식 변경한다.
  - 해당 컴포넌트에서 pros로 url을 넘겨주는 방식에서 Sider를 withRouter로 감싸서 처리한다.
- 코드 스플리팅 적용한다.
- 레이아웃 커먼 삭제한다.
  - 레이아웃 커먼을 쓰게 되면 매 컴포넌트마다 레이아웃 커먼을 선언해줘야함. 루트에서 한번만 하도록 변경한다.